### PR TITLE
[14.0][IMP] egd_stock_picking_invoicing_custom: default_get and field in sale order

### DIFF
--- a/egd_stock_picking_invoicing_custom/__manifest__.py
+++ b/egd_stock_picking_invoicing_custom/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["stock_picking_invoicing"],
     "data": [
         "views/account_move.xml",
+        "views/sale_order.xml",
         "wizards/stock_invoice_onshipping.xml",
     ],
 }

--- a/egd_stock_picking_invoicing_custom/models/__init__.py
+++ b/egd_stock_picking_invoicing_custom/models/__init__.py
@@ -1,1 +1,2 @@
 from . import account_move
+from . import sale_order

--- a/egd_stock_picking_invoicing_custom/models/sale_order.py
+++ b/egd_stock_picking_invoicing_custom/models/sale_order.py
@@ -1,0 +1,11 @@
+# Copyright 2024 - TODAY, Kaynnan Lemes <kaynnan.lemes@escodoo.com.br>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+
+    _inherit = "sale.order"
+
+    production_date = fields.Date(string="Production Date", required=True)

--- a/egd_stock_picking_invoicing_custom/views/sale_order.xml
+++ b/egd_stock_picking_invoicing_custom/views/sale_order.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 - TODAY, Kaynnan Lemes <kaynnan.lemes@escodoo.com.br>
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="sale_order_move_form_view">
+        <field name="name">sale.order.form (in egd_sale_custom)</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='date_order']" position="after">
+                <field name="production_date" string="Production Date" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/egd_stock_picking_invoicing_custom/wizards/stock_invoice_onshipping.py
+++ b/egd_stock_picking_invoicing_custom/wizards/stock_invoice_onshipping.py
@@ -1,13 +1,24 @@
 # Copyright 2024 - TODAY, Kaynnan Lemes <kaynnan.lemes@escodoo.com.br>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockInvoiceOnshipping(models.TransientModel):
     _inherit = "stock.invoice.onshipping"
 
-    production_date = fields.Date(string="Production Date")
+    production_date = fields.Date(string="Production Date", required=True)
+
+    @api.model
+    def default_get(self, fields_list):
+        defaults = super().default_get(fields_list)
+        if self.env.context.get("active_model") == "stock.picking":
+            picking_id = self.env.context.get("active_id")
+            if picking_id:
+                picking = self.env["stock.picking"].browse(picking_id)
+                if picking.sale_id and picking.sale_id.production_date:
+                    defaults["production_date"] = picking.sale_id.production_date
+        return defaults
 
     def _action_generate_invoices(self):
         invoices = super()._action_generate_invoices()


### PR DESCRIPTION
cc @marcelsavegnago @douglascstd @WesleyOliveira98 

Insert the `production_date` field into the `sale.order `model, positioning it after the `date_order` field. Ensure that its value is automatically retrieved and set in the wizard for creating invoices, specifically in the Production Date field.