### PR TITLE
[16.0][FIX] egd_purchase_request_custom: view optional analytic_distribution

### DIFF
--- a/egd_purchase_request_custom/views/purchase_request_view.xml
+++ b/egd_purchase_request_custom/views/purchase_request_view.xml
@@ -25,6 +25,7 @@
                 position="attributes"
             >
                 <attribute name="required">1</attribute>
+                <attribute name="optional" />
             </xpath>
 
             <!-- Insert 'egd_target_quantity' field after 'product_qty' in 'line_ids'-->


### PR DESCRIPTION
## Obejtivo da PR

Já que é um campo obrigatorio deixar ele visivel na view

<img width="1920" height="961" alt="PRINT_EGD_PR" src="https://github.com/user-attachments/assets/14a01d86-0196-4876-801e-9272a0111275" />
